### PR TITLE
Add local cache configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ go.work*
 
 # Firebase config file
 config/firebase-config.json
+
+# Local aurora config file.
+aurora-config.json

--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -1,9 +1,11 @@
 package routes
 
 import (
+	"log"
 	"time"
 
 	"ricochet/aurora/api/services"
+	"ricochet/aurora/types"
 
 	"github.com/gofiber/fiber/v2"
 )
@@ -19,7 +21,7 @@ func HitTest(c *fiber.Ctx) error {
 // ROUTE: /server
 // DESC: Get server details
 func GetServer(c *fiber.Ctx) error {
-	server, _ := services.GetServer()
+	server := services.GetServer()
 	return c.JSON(server)
 }
 
@@ -27,17 +29,15 @@ func GetServer(c *fiber.Ctx) error {
 // ROUTE: /server
 // DESC: Update server details
 func UpdateServer(c *fiber.Ctx) error {
-	server := services.NewServer()
+	// server := new(types.Server)
+	var server types.Server
 
 	// Check for errors in body.
-	if err := c.BodyParser(server); err != nil {
-		return err
+	if err := c.BodyParser(&server); err != nil {
+		log.Fatalf("Error in provided body: \n%v", err)
 	}
 
-	server, err := services.UpdateServer(c, server)
-	if err != nil {
-		return err
-	}
+	server = services.UpdateServer(c, server)
 
 	return c.JSON(server)
 }
@@ -46,10 +46,9 @@ func UpdateServer(c *fiber.Ctx) error {
 // ROUTE: /server
 // DESC: Delete server
 func RemoveServer(c *fiber.Ctx) error {
-	if err := services.RemoveServer(c); err != nil {
-		return err
-	}
+	services.RemoveServer(c)
 
+	// Return success if the server is deleted.
 	return c.JSON(struct {
 		Status string `json:"status"`
 	}{Status: "success"})

--- a/config/config.go
+++ b/config/config.go
@@ -2,8 +2,12 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"ricochet/aurora/types"
+
+	"dario.cat/mergo"
 )
 
 // configPath is the path to the config file.
@@ -11,83 +15,110 @@ var configPath string = "/config.json"
 
 // Config is a struct of the local, persistent configuration of this instance.
 type Config struct {
-	ClusterID string       // The cluster this instance belongs to.
-	ID        string       // The identifier of the server.
-	Server    types.Server // The server configuration.
-}
-
-// Init runs a setup of the configuration on first run of the application.
-func Init() error {
-	return nil
+	ID        string       `json:"id" yaml:"id" xml:"id" form:"id"`                             // The identifier of the server.
+	ClusterID string       `json:"clusterId" yaml:"clusterId" xml:"clusterId" form:"clusterId"` // The cluster this instance belongs to.
+	Server    types.Server `json:"server" yaml:"server" xml:"server" form:"server"`             // The server configuration.
 }
 
 // Update creates or modifies config properties.
-func Update(config Config) (Config, error) {
-	// Get the working directory.
-	wd, err := os.Getwd()
+func Update(newConfig Config) (Config, error) {
+	// Get the file.
+	file, err := getFile()
 	if err != nil {
-		return Config{}, err
+		return Config{}, fmt.Errorf("Update() error getting file: %v", err)
+	}
+	defer file.Close()
+
+	// Read the existing config.
+	config, err := Read()
+	if err != nil {
+		return Config{}, fmt.Errorf("Update() error reading config: %v", err)
 	}
 
-	as := []A{
-		{Name: "John", Surname: "Black"},
-		{Name: "Mary", Surname: "Brown"},
+	// Merge the configs, taking precidence from the input config.
+	if err := mergo.Merge(&config, newConfig, mergo.WithOverride); err != nil {
+		return Config{}, fmt.Errorf("Update() error merging configs: %v", err)
 	}
-	as_json, _ := json.MarshalIndent(as, "", "\t")
-	f.Write(as_json)
+
+	// Update the file.
+	as_json, jsonErr := json.MarshalIndent(config, "", "\t")
+	if jsonErr != nil {
+		return Config{}, fmt.Errorf("Update() error converting config to json: %v", err)
+	}
+	if writeErr := os.WriteFile(file.Name(), as_json, 0666); writeErr != nil {
+		return Config{}, fmt.Errorf("Update() error writing json to file: %v", err)
+	}
+
+	return config, nil
 }
 
 // Read returns the current configuration.
 func Read() (Config, error) {
-	// Get the working directory.
-	wd, err := os.Getwd()
+	// Get the file.
+	file, err := getFile()
 	if err != nil {
-		return Config{}, err
+		return Config{}, fmt.Errorf("Read() error getting file: %v", err)
 	}
+	defer file.Close()
 
 	// Load the file; returns []byte.
-	f, err := os.ReadFile(wd + configPath)
+	content, err := os.ReadFile(file.Name())
 	if err != nil {
-		return Config{}, err
+		return Config{}, fmt.Errorf("Read() error reading json from file: %v", err)
 	}
 
 	// Create an empty Config to be are target of unmarshalling.
 	var config Config
 
 	// Unmarshal the JSON file into empty Config.
-	if err := json.Unmarshal(f, &config); err != nil {
-		return Config{}, err
+	if err := json.Unmarshal(content, &config); err != nil {
+		return Config{}, fmt.Errorf("Read() error converting json from file to Config: %v", err)
 	}
 
 	return config, nil
 }
 
-func createFile() (*os.File, error) {
+// getFile returns the config file.
+// Additionally it will create the file if it does not exist.
+func getFile() (*os.File, error) {
+	var file *os.File
+
 	// Get the working directory.
-	wd, err := os.Getwd()
-	if err != nil {
-		return &os.File{}, err
+	wd, wdErr := os.Getwd()
+	if wdErr != nil {
+		return file, fmt.Errorf("getFile() error getting working directory: %v", wdErr)
 	}
 
-	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+	// Check path exists.
+	_, pathErr := os.Stat(wd + configPath)
+
+	// Scope variables correctly.
+	var err error
+
+	if errors.Is(pathErr, os.ErrNotExist) {
 		// Create the file if it doesn't exist.
-		f, err := os.Create(wd + configPath)
+		file, err = os.Create(wd + configPath)
 		if err != nil {
-			return &os.File{}, err
+			return &os.File{}, fmt.Errorf("getFile() error creating file: %v", err)
 		}
-		defer f.Close()
-		return f, nil
-	} else if os.IsExist(err) {
+
+		// Create an empty json file.
+		as_json, jsonErr := json.MarshalIndent(struct{}{}, "", "\t")
+		if jsonErr != nil {
+			return &os.File{}, fmt.Errorf("getFile() error marshalling struct{}{} to json: %v", jsonErr)
+		}
+		if writeErr := os.WriteFile(file.Name(), as_json, 0666); writeErr != nil {
+			return &os.File{}, fmt.Errorf("getFile() error writing to file: %v", writeErr)
+		}
+	} else if !errors.Is(pathErr, os.ErrNotExist) {
 		// Otherwise return the existing file.
-		f, err := os.Open(wd + configPath)
+		file, err = os.Open(wd + configPath)
 		if err != nil {
-			return &os.File{}, err
+			return &os.File{}, fmt.Errorf("getFile() error opening file: %v", err)
 		}
-		defer f.Close()
-		return f, nil
 	} else {
-		if err != nil {
-			return &os.File{}, err
-		}
+		return &os.File{}, fmt.Errorf("getFile() error checking path exists: %v", pathErr)
 	}
+
+	return file, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // configPath is the path to the config file.
-var configPath string = "/config.json"
+var configPath string = "/aurora-config.json"
 
 // Config is a struct of the local, persistent configuration of this instance.
 type Config struct {
@@ -36,7 +36,8 @@ func Update(newConfig Config) (Config, error) {
 	}
 
 	// Merge the configs, taking precidence from the input config.
-	if err := mergo.Merge(&config, newConfig, mergo.WithOverride); err != nil {
+	// WithOverwriteWithEmptyValue allows us to overwrite populated fields even with empty fields.
+	if err := mergo.Merge(&config, newConfig, mergo.WithOverwriteWithEmptyValue); err != nil {
 		return Config{}, fmt.Errorf("Update() error merging configs: %v", err)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"ricochet/aurora/types"
+)
+
+// configPath is the path to the config file.
+var configPath string = "/config.json"
+
+// Config is a struct of the local, persistent configuration of this instance.
+type Config struct {
+	ClusterID string       // The cluster this instance belongs to.
+	ID        string       // The identifier of the server.
+	Server    types.Server // The server configuration.
+}
+
+// Init runs a setup of the configuration on first run of the application.
+func Init() error {
+	return nil
+}
+
+// Update creates or modifies config properties.
+func Update(config Config) (Config, error) {
+	// Get the working directory.
+	wd, err := os.Getwd()
+	if err != nil {
+		return Config{}, err
+	}
+
+	as := []A{
+		{Name: "John", Surname: "Black"},
+		{Name: "Mary", Surname: "Brown"},
+	}
+	as_json, _ := json.MarshalIndent(as, "", "\t")
+	f.Write(as_json)
+}
+
+// Read returns the current configuration.
+func Read() (Config, error) {
+	// Get the working directory.
+	wd, err := os.Getwd()
+	if err != nil {
+		return Config{}, err
+	}
+
+	// Load the file; returns []byte.
+	f, err := os.ReadFile(wd + configPath)
+	if err != nil {
+		return Config{}, err
+	}
+
+	// Create an empty Config to be are target of unmarshalling.
+	var config Config
+
+	// Unmarshal the JSON file into empty Config.
+	if err := json.Unmarshal(f, &config); err != nil {
+		return Config{}, err
+	}
+
+	return config, nil
+}
+
+func createFile() (*os.File, error) {
+	// Get the working directory.
+	wd, err := os.Getwd()
+	if err != nil {
+		return &os.File{}, err
+	}
+
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		// Create the file if it doesn't exist.
+		f, err := os.Create(wd + configPath)
+		if err != nil {
+			return &os.File{}, err
+		}
+		defer f.Close()
+		return f, nil
+	} else if os.IsExist(err) {
+		// Otherwise return the existing file.
+		f, err := os.Open(wd + configPath)
+		if err != nil {
+			return &os.File{}, err
+		}
+		defer f.Close()
+		return f, nil
+	} else {
+		if err != nil {
+			return &os.File{}, err
+		}
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,161 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"ricochet/aurora/types"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// TestRead calls Read,
+// checking for a config in return.
+func TestRead(t *testing.T) {
+	// Cleanup at the end of the test.
+	t.Cleanup(func() {
+		if err := cleanup(); err != nil {
+			t.Fatalf("TestUpdate() error cleaning up:\n%v", err)
+		}
+	})
+
+	var want Config = Config{}
+
+	got, err := Read()
+
+	if err != nil {
+		t.Fatalf("TestUpdate() returned an error: \n%v", err)
+	}
+	// Use cmp for more complex types.
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("TestUpdate() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestUpdateCreate calls Update with a valid config,
+// with no existing config present, it will first create the config,
+// then it will update the config.
+// It will check the config file and config have been created and updated.
+func TestUpdate(t *testing.T) {
+	// Cleanup at the end of the test.
+	t.Cleanup(func() {
+		if err := cleanup(); err != nil {
+			t.Fatalf("TestUpdate() (create) error cleaning up:\n%v", err)
+		}
+	})
+
+	// Get the working directory.
+	wd, wdErr := os.Getwd()
+	if wdErr != nil {
+		t.Fatalf("TestUpdate() (create) could not get the working directory, error: \n%v", wdErr)
+	}
+
+	// Test creation.
+	var createWant Config = Config{
+		ClusterID: "myclusterid",
+		Server: types.Server{
+			ID:   "00000001",
+			Size: "xs",
+			Game: types.Game{
+				Name:      "minecraft_java",
+				Modloader: "fabric",
+			},
+			Network: types.Network{
+				Type: "private",
+			},
+		},
+	}
+
+	createGot, createErr := Update(Config{
+		ClusterID: "myclusterid",
+		Server: types.Server{
+			ID:   "00000001",
+			Size: "xs",
+			Game: types.Game{
+				Name:      "minecraft_java",
+				Modloader: "fabric",
+			},
+			Network: types.Network{
+				Type: "private",
+			},
+		},
+	})
+
+	if createErr != nil {
+		t.Fatalf("TestUpdate() (create) returned an error: \n%v", createErr)
+	}
+	// Use cmp for more complex types.
+	if diff := cmp.Diff(createWant, createGot); diff != "" {
+		t.Fatalf("TestUpdate() (create) mismatch (-want +got):\n%s", diff)
+	}
+
+	// Check if the file exists.
+	if _, pathErr := os.Stat(wd + configPath); errors.Is(pathErr, os.ErrNotExist) {
+		t.Fatalf("TestUpdate() (create) file was not created: \n%v", pathErr)
+	}
+
+	// Test updating.
+	var modifyWant Config = Config{
+		ID:        "00000002",
+		ClusterID: "mynewclusterid",
+		Server: types.Server{
+			ID:   "00000002",
+			Size: "xl",
+			Game: types.Game{
+				Name:      "valheim",
+				Modloader: "vanilla",
+			},
+			Network: types.Network{
+				Type: "public",
+			},
+		},
+	}
+
+	modifyGot, modifyErr := Update(Config{
+		ID:        "00000002",
+		ClusterID: "mynewclusterid",
+		Server: types.Server{
+			ID:   "00000002",
+			Size: "xl",
+			Game: types.Game{
+				Name:      "valheim",
+				Modloader: "vanilla",
+			},
+			Network: types.Network{
+				Type: "public",
+			},
+		},
+	})
+
+	if modifyErr != nil {
+		t.Fatalf("TestUpdate() (modify) returned an error: \n%v", modifyErr)
+	}
+	// Use cmp for more complex types.
+	if diff := cmp.Diff(modifyWant, modifyGot); diff != "" {
+		t.Fatalf("TestUpdate() (modify) mismatch (-want +got):\n%s", diff)
+	}
+
+	// Check if the file exists.
+	if _, pathErr := os.Stat(wd + configPath); errors.Is(pathErr, os.ErrNotExist) {
+		t.Fatalf("TestUpdateCreate() (modify) file was not created: \n%v", pathErr)
+	}
+}
+
+// cleanup removes the config file if it exists.
+func cleanup() error {
+	// Get the working directory.
+	wd, wdErr := os.Getwd()
+	if wdErr != nil {
+		return fmt.Errorf("cleanup() error getting working directory: %v", wdErr)
+	}
+
+	// Remove the file if it exists.
+	if _, pathErr := os.Stat(wd + configPath); !errors.Is(pathErr, os.ErrNotExist) {
+		if err := os.Remove(wd + configPath); err != nil {
+			return fmt.Errorf("cleanup() error removing file: %v", err)
+		}
+	}
+
+	return nil
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -104,7 +104,7 @@ func TestUpdate(t *testing.T) {
 			Size: "xl",
 			Game: types.Game{
 				Name:      "valheim",
-				Modloader: "vanilla",
+				Modloader: "",
 			},
 			Network: types.Network{
 				Type: "public",
@@ -120,7 +120,7 @@ func TestUpdate(t *testing.T) {
 			Size: "xl",
 			Game: types.Game{
 				Name:      "valheim",
-				Modloader: "vanilla",
+				Modloader: "",
 			},
 			Network: types.Network{
 				Type: "public",

--- a/config/go.mod
+++ b/config/go.mod
@@ -1,3 +1,8 @@
 module ricochet/aurora/config
 
 go 1.20
+
+require (
+	dario.cat/mergo v1.0.0
+	github.com/google/go-cmp v0.5.9
+)

--- a/config/go.mod
+++ b/config/go.mod
@@ -1,0 +1,3 @@
+module ricochet/aurora/config
+
+go 1.20

--- a/config/go.sum
+++ b/config/go.sum
@@ -1,0 +1,7 @@
+dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
+dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/test-server.json
+++ b/test-server.json
@@ -1,0 +1,11 @@
+{
+	"id": "00000001",
+	"size": "xs",
+	"game": {
+		"name": "minecraft_java",
+		"modloader": "vanilla"
+	},
+	"network": {
+		"type": "private"
+	}
+}

--- a/types/types.go
+++ b/types/types.go
@@ -2,21 +2,21 @@ package types
 
 // Game is details about the video game that the server is hosting.
 type Game struct {
-	Name      string `json:"name" xml:"name" form:"name"`
-	Modloader string `json:"modloader" xml:"modloader" form:"modloader"`
+	Name      string `json:"name" yaml:"name" xml:"name" form:"name"`
+	Modloader string `json:"modloader" yaml:"modloader" xml:"modloader" form:"modloader"`
 }
 
 // Network is configuration of the networking for the instance.
 type Network struct {
-	Type string `json:"type" xml:"type" form:"type"`
+	Type string `json:"type" yaml:"type" xml:"type" form:"type"`
 }
 
 // Server is a set of useful details about a game server instance.
 type Server struct {
-	ID      string `json:"id" xml:"id" form:"id"`
-	Size    string `json:"size" xml:"size" form:"size"`
-	Game    Game
-	Network Network
+	ID      string  `json:"id" yaml:"id" xml:"id" form:"id"`
+	Size    string  `json:"size" yaml:"size" xml:"size" form:"size"`
+	Game    Game    `json:"game" yaml:"game" xml:"game" form:"game"`
+	Network Network `json:"network" yaml:"network" xml:"network" form:"network"`
 }
 
 // // Server is a set of useful details about a game server instance.


### PR DESCRIPTION
Server attributes can be replaced with DB in future.
The ID will always remain.

Adds a local configuration, modified and read by server api calls.